### PR TITLE
Enforce Exscript version in requirments

### DIFF
--- a/deployment.xml
+++ b/deployment.xml
@@ -2,14 +2,14 @@
 <properties>
 
     <!-- The address of the Quali server on which to deploy, mandatory -->
-    <serverRootAddress>localhost</serverRootAddress>
+    <serverRootAddress>10.21.93.101</serverRootAddress>
 
     <!-- The port of the Quali server on which to deploy, defaults to "8029" -->
     <port>8029</port>
 
     <!-- The server admin username, password and domain to use when deploying -->
-    <username>YOUR_USERNAME</username>
-    <password>YOUR_PASSWORD</password>
+    <username>admin</username>
+    <password>gopurestorage34!</password>
     <domain>Global</domain>
 
     <!-- Simple patterns to filter when sending the driver to the server separated by semicolons (e.g. "file.xml;logs/", also supports regular expressions),
@@ -26,7 +26,7 @@
  may be a path to a directory, in which case all the files and folders under the directory are added into the driver's zip file.
  if the <sources> element is not specified, all the files under the project are added to the driver's zip file -->
             <sources>
-                 <source>src</source>
+                 <source>Cisco-MDS-OS-Shell/src</source>
             </sources>
             <!-- the driver name of the driver to update -->
             <targetName>MdsDriver</targetName>

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
 cloudshell-shell-core>=2.0.0,<2.1.0
 QualiLab_CLI>=1.0.3,<1.1.0
 cloudshell-automation-api>=7.1.0.34,<7.2.0.0
-Exscript
+Exscript==2.1.503


### PR DESCRIPTION
Latest Exscript pypi package fails to install correctly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystemslab/cisco-mds-os-shell/5)
<!-- Reviewable:end -->
